### PR TITLE
Update artifactural to 3.0.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ repositories {
 }
 
 dependencies {
-	shade 'net.minecraftforge:artifactural:3.0.10'
+	shade 'net.minecraftforge:artifactural:3.0.17'
 	// Thanks Shrimp...
 	shade 'net.minecraftforge:unsafe:0.2.0'
 	shade 'com.google.guava:guava:30.1-jre'


### PR DESCRIPTION
Fixes 
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':Common'.
> Failed to notify project evaluation listener.
   > 'void org.gradle.api.internal.artifacts.repositories.descriptor.FlatDirRepositoryDescriptor.<init>(java.lang.String, java.util.Collection)'
   When running on Gradle 8.2 > 