### PR TITLE
Fix manifest issues (1.20.1)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ minecraft_version=1.20
 forge_version=46.0.2
 fabric_version=0.86.1+1.20.1
 fabric_loader_version=0.14.19
-version=1.20.1-2.0.1
+version=1.20.1-2.0.2
 
 # Gradle
 org.gradle.daemon=true

--- a/src/main/java/com/matyrobbrt/registrationutils/gradle/RegExtension.java
+++ b/src/main/java/com/matyrobbrt/registrationutils/gradle/RegExtension.java
@@ -277,6 +277,7 @@ public class RegExtension {
                 t.from(project.zipTree(sources.get().getOutputJar()));
                 t.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE);
                 t.dependsOn(classes, sources);
+                configureManifest(t);
             });
             TaskProvider<Jar> finalCombined = combined;
             ideSync.configure(t -> t.dependsOn(finalCombined));
@@ -312,14 +313,13 @@ public class RegExtension {
                 t.from(project.zipTree(common.get().getArchiveFile()));
                 t.from(project.zipTree(loaderSpecific.get().getArchiveFile()));
                 t.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE);
+                configureManifest(t);
             });
             TaskProvider<Jar> finalJoinedJar = joinedJar;
             ideSync.configure(t -> t.dependsOn(finalJoinedJar));
         }
         return joinedJar;
     }
-
-
 
     private TaskProvider<Jar> joinedPartialJarTask(RegistrationUtilsExtension.SubProject.Type type, boolean sources) {
         TaskProvider<Jar> joinedJar;
@@ -336,11 +336,16 @@ public class RegExtension {
                 t.from(project.zipTree(loaderSpecific.get().getOutputJar()));
                 t.setDuplicatesStrategy(DuplicatesStrategy.INCLUDE);
                 t.dependsOn(common, loaderSpecific);
+                configureManifest(t);
             });
             TaskProvider<Jar> finalJoinedJar = joinedJar;
             ideSync.configure(t -> t.dependsOn(finalJoinedJar));
         }
         return joinedJar;
+    }
+
+    private void configureManifest(Jar jar) {
+        jar.manifest(mf -> mf.attributes(Map.of("FMLModType", "GAMELIBRARY", "Implementation-Version", RegistrationUtilsPlugin.JPMS_VERSION)));
     }
 
     private void handleTransformation(Path classesOut) {

--- a/src/main/java/com/matyrobbrt/registrationutils/gradle/RegExtension.java
+++ b/src/main/java/com/matyrobbrt/registrationutils/gradle/RegExtension.java
@@ -71,6 +71,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 
 public class RegExtension {
 
@@ -345,7 +346,10 @@ public class RegExtension {
     }
 
     private void configureManifest(Jar jar) {
-        jar.manifest(mf -> mf.attributes(Map.of("FMLModType", "GAMELIBRARY", "Implementation-Version", RegistrationUtilsPlugin.JPMS_VERSION)));
+        Map<String, String> map = new HashMap<>();
+        map.put("FMLModType", "GAMELIBRARY");
+        map.put("Implementation-Version", RegistrationUtilsPlugin.JPMS_VERSION);
+        jar.manifest(mf -> mf.attributes(map));
     }
 
     private void handleTransformation(Path classesOut) {

--- a/src/main/java/com/matyrobbrt/registrationutils/gradle/RegistrationUtilsPlugin.java
+++ b/src/main/java/com/matyrobbrt/registrationutils/gradle/RegistrationUtilsPlugin.java
@@ -37,9 +37,11 @@ import org.gradle.api.plugins.UnknownPluginException;
 public class RegistrationUtilsPlugin implements Plugin<Project> {
 
     public static final String VERSION;
+    public static final String JPMS_VERSION;
     static {
         final String ver = RegistrationUtilsPlugin.class.getPackage().getImplementationVersion();
         VERSION = ver == null ? "dev" : ver;
+        JPMS_VERSION = Character.isDigit(VERSION.charAt(0)) ? VERSION : ("0.0" + VERSION);
     }
 
     public static final String CONFIGURATION_NAME = "registrationUtils";


### PR DESCRIPTION
`joined` jars for forge are currently missing the necessary manifest attribute; this simply ports that forwards from 9bdcca3ab6f5ab7dd592c2a2ba6056a2f9789384.