### PR TITLE
Updated to 26.1

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'java'
-    id 'net.neoforged.moddev' version '2.0.123'
+    id 'net.neoforged.moddev'
 }
 
-java.toolchain.languageVersion = JavaLanguageVersion.of(21)
+java.toolchain.languageVersion = JavaLanguageVersion.of(java_version)
 
 neoForge {
     neoFormVersion = "${neoform_version}"

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -24,6 +24,10 @@ dependencies {
     implementation project(":Common")
 }
 
+processResources {
+    from project(":Common").sourceSets.main.resources
+}
+
 jar {
     rename 'dummy_fabric.mod.json', 'fabric.mod.json'
     inputs.property "version", project.version

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'fabric-loom' version '1.13.3'
     id 'maven-publish'
     id 'idea'
+    id 'net.fabricmc.fabric-loom'
 }
 
 loom {
@@ -12,21 +12,16 @@ loom {
 
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
-    mappings loom.officialMojangMappings()
 
-    modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
-    modImplementation(platform("net.fabricmc.fabric-api:fabric-api-bom:${fabric_version}"))
-    modImplementation('net.fabricmc.fabric-api:fabric-command-api-v2')
-    modImplementation('net.fabricmc.fabric-api:fabric-registry-sync-v0')
+    implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
+    implementation('net.fabricmc.fabric-api:fabric-command-api-v2')
+    implementation('net.fabricmc.fabric-api:fabric-registry-sync-v0')
 
-    implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
+    implementation "com.google.code.findbugs:jsr305:3.0.1"
     compileOnly 'com.google.auto.service:auto-service:1.0.1'
     annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
     implementation project(":Common")
-}
-
-processResources {
-    from project(":Common").sourceSets.main.resources
 }
 
 jar {

--- a/Fabric/src/main/java/com/matyrobbrt/registrationutils/fabric/FabricDatapackRegistryBuilder.java
+++ b/Fabric/src/main/java/com/matyrobbrt/registrationutils/fabric/FabricDatapackRegistryBuilder.java
@@ -38,6 +38,7 @@ import net.minecraft.core.*;
 import net.minecraft.data.DataProvider;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.RegistryDataLoader;
+import net.minecraft.resources.RegistryValidator;
 import net.minecraft.resources.ResourceKey;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -130,14 +131,14 @@ public class FabricDatapackRegistryBuilder<T> implements DatapackRegistryBuilder
             try {
                 final List<RegistryDataLoader.RegistryData<?>> mutableCopy = new ArrayList<>(RegistryDataLoader.WORLDGEN_REGISTRIES);
                 mutableCopy.add(new RegistryDataLoader.RegistryData<>(
-                        key, elementCodec, false
+                        key, elementCodec, RegistryValidator.none()
                 ));
                 UNSAFE.putObject(RegistryDataLoader.class, offset$WORLDGEN_REGISTRIES, List.copyOf(mutableCopy));
 
                 if (networkCodec != null) {
                     final List<RegistryDataLoader.RegistryData<?>> mutableNetwork = new ArrayList<>(RegistryDataLoader.SYNCHRONIZED_REGISTRIES);
                     mutableNetwork.add(new RegistryDataLoader.RegistryData<>(
-                            key, networkCodec, false
+                            key, networkCodec, RegistryValidator.none()
                     ));
                     UNSAFE.putObject(RegistryDataLoader.class, offset$SYNCHRONIZED_REGISTRIES, List.copyOf(mutableNetwork));
 

--- a/NeoForge/build.gradle
+++ b/NeoForge/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'idea'
     id 'maven-publish'
     id 'java-library'
-    id 'net.neoforged.moddev' version '2.0.123'
+    id 'net.neoforged.moddev'
 }
 
 neoForge {

--- a/build.gradle
+++ b/build.gradle
@@ -4,27 +4,23 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
-buildscript {
-	dependencies {
-		classpath 'org.codehaus.groovy:groovy-all:3.0.9'
-		classpath 'org.ow2.asm:asm:9.7'
-	}
-}
-
 plugins {
 	id 'java-gradle-plugin'
 	id 'maven-publish'
 	id 'com.gradle.plugin-publish' version '1.2.1'
 	id 'idea'
 	id 'com.github.johnrengelman.shadow' version '8.1.1'
-	id 'org.cadixdev.licenser' version '0.6.1' apply false
+	id 'net.neoforged.licenser' version '0.7.5' apply false
 	// Required for NeoGradle
 	id "org.jetbrains.gradle.plugin.idea-ext" version "1.1.8"
+
+	id 'net.fabricmc.fabric-loom' version '1.15-SNAPSHOT' apply false
+    id 'net.neoforged.moddev' version '2.0.141' apply false
 }
 
 subprojects {
 	apply plugin: 'java'
-	java.toolchain.languageVersion = JavaLanguageVersion.of(21)
+	java.toolchain.languageVersion = JavaLanguageVersion.of(java_version)
 }
 
 if (System.getenv('GPP_KEY')) {
@@ -53,10 +49,10 @@ repositories {
 }
 
 dependencies {
-	shade 'org.ow2.asm:asm:9.7'
-	shade 'org.ow2.asm:asm-tree:9.7'
-	shade 'me.lucko:jar-relocator:1.5'
-	shade 'commons-io:commons-io:2.13.0'
+	shade 'org.ow2.asm:asm:9.8'
+	shade 'org.ow2.asm:asm-tree:9.8'
+	shade 'me.lucko:jar-relocator:1.7'
+	shade 'commons-io:commons-io:2.21.0'
 
 	implementation 'org.jetbrains.gradle.plugin.idea-ext:org.jetbrains.gradle.plugin.idea-ext.gradle.plugin:1.1.8'
 
@@ -152,8 +148,8 @@ tasks.named('shadowJar', ShadowJar).configure {
 	archiveClassifier.set('')
 	configurations = [project.configurations.shade]
 	manifest.attributes(makeAttributes())
-	enableRelocation true
-	relocationPrefix("com.matyrobbrt.registrationutils.gradle.shade")
+	enableRelocation = true
+	relocationPrefix = "com.matyrobbrt.registrationutils.gradle.shade"
 }
 
 jar {
@@ -164,11 +160,11 @@ Map<?, ?> makeAttributes() {
 	final var actualDateTime = OffsetDateTime.now(ZoneOffset.UTC).withNano(0)
 	final var currentDateTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(actualDateTime)
 	return [
-		'Maven-Artifact'          : "${project.group}:${archivesBaseName}:${project.version}",
-		'Specification-Title'     : archivesBaseName,
+		'Maven-Artifact'          : "${project.group}:${project.name}:${project.version}",
+		'Specification-Title'     : project.name,
 		'Specification-Vendor'    : 'Matyrobbrt',
 		'Specification-Version'   : '1',
-		'Implementation-Title'    : archivesBaseName,
+		'Implementation-Title'    : project.name,
 		'Implementation-Version'  : "${project.version}",
 		'Implementation-Vendor'   : 'Matyrobbrt',
 		'Implementation-Timestamp': currentDateTime,
@@ -177,11 +173,19 @@ Map<?, ?> makeAttributes() {
 }
 
 allprojects {
-	apply plugin: 'org.cadixdev.licenser'
+	apply plugin: 'net.neoforged.licenser'
 	license {
 		header = rootProject.file('licenseheader.txt')
 	}
 	repositories {
 		mavenCentral()
 	}
+
+    configurations.all { //Pull specific asm versions, to make sure dependencies are not pulling old versions
+        resolutionStrategy {
+            force 'org.ow2.asm:asm:9.8'
+            force 'org.ow2.asm:asm-tree:9.8'
+            force 'org.ow2.asm:asm-commons:9.8'
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
-minecraft_version=1.21.11
-neoforge_version=21.11.3-beta
-neoform_version=1.21.11-20251209.172050
-fabric_version=0.139.4+1.21.11
-fabric_loader_version=0.18.2
-version=1.21.11-0.1.0
+minecraft_version=26.1
+neoforge_version=26.1.0.5-beta
+neoform_version=26.1-1
+fabric_version=0.144.3+26.1
+fabric_loader_version=0.18.5
+java_version=25
+version=26.1-0.1.0
 
 # Gradle
 org.gradle.daemon=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 rootProject.name = "registrationutils"

--- a/src/main/java/com/matyrobbrt/registrationutils/gradle/RegExtension.java
+++ b/src/main/java/com/matyrobbrt/registrationutils/gradle/RegExtension.java
@@ -394,11 +394,4 @@ public class RegExtension {
                 .map(Path::toFile)
                 .forEach(File::delete);
     }
-
-//    public static class JarTask extends Jar { //Seemed unused? Required a plethora of methods to be implemented now.
-//        @Override
-//        public void copy() {
-//            super.copy();
-//        }
-//    }
 }

--- a/src/main/java/com/matyrobbrt/registrationutils/gradle/RegExtension.java
+++ b/src/main/java/com/matyrobbrt/registrationutils/gradle/RegExtension.java
@@ -395,11 +395,10 @@ public class RegExtension {
                 .forEach(File::delete);
     }
 
-    public static class JarTask extends Jar {
-        @Override
-        public void copy() {
-            super.copy();
-        }
-
-    }
+//    public static class JarTask extends Jar { //Seemed unused? Required a plethora of methods to be implemented now.
+//        @Override
+//        public void copy() {
+//            super.copy();
+//        }
+//    }
 }


### PR DESCRIPTION
**Changes**
- Updated to Minecraft 26.1
- Now supports Gradle 9.2
- Works on Java 25
- Moved away from using 'org.cadixdev.licenser', as it didn't work on Gradle 9.0+. Swapped to using  net.neoforged.licenser instead
- Updated various dependencies
- All dependencies versions is now only set in either gradle.properties, or the main build.gradle

I've tried to keep the changes as minimal as possible. Very little actually code change, primarily buildscript changes needed.